### PR TITLE
Remove debug line

### DIFF
--- a/src/dependencypool.cpp
+++ b/src/dependencypool.cpp
@@ -92,7 +92,6 @@ CreatorType typeForKey(const QString &key)
 {
     if (!d->creators.contains(key))
         return CreatorType::Unknown;
-    qDebug() << (int)d->creators.value(key)->_type;
     return d->creators.value(key)->_type;
 }
 


### PR DESCRIPTION
Remove debug line, which always prints a number to the console, thus polluting it.

Thank you for this great project!
I am using it with Qt 6.4 and CMake.

Here is my CMake file if you are interested in it:
[CMakeLists.txt](https://github.com/HamedMasafi/QInjection/files/9860977/CMakeLists.txt)
